### PR TITLE
Added comments to jobs

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,16 @@
+class CommentsController < ApplicationController
+
+  def create
+    @company = Company.find(params[:company_id])
+    @job = @company.jobs.find(params[:job_id])
+    @comment = @job.comments.new(comment_params)
+    @comment.save
+    redirect_to company_job_path(@company, @job)
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:content)
+  end
+end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -26,6 +26,8 @@ class JobsController < ApplicationController
   def show
     @company = Company.find(params[:company_id])
     @job = Job.find(params[:id])
+    @comments = Comment.all
+    @comment = Comment.new
   end
 
   def edit

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,3 @@
+class Comment < ApplicationRecord
+  belongs_to :job
+end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -2,4 +2,5 @@ class Job < ApplicationRecord
   validates :title, :level_of_interest, :city, presence: true
   belongs_to :company
   belongs_to :category
+  has_many :comments
 end

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -11,3 +11,17 @@ City: <%= @job.city %>
 <br>
 
 Company: <%= link_to @job.company.name, company_path(@job.company) %>
+
+Add A Comment:
+<%= form_for [@company, @job, @comment] do |f| %>
+
+  <%= f.label :content %>
+  <%= f.text_area :content %>
+
+  <%= f.submit %>
+<% end %>
+
+Comments:
+<% @comments.each do |comment| %>
+  <%= comment.content %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
 
   resources :companies do
-    resources :jobs
+    resources :jobs do
+      resources :comments do
+      end
+    end
   end
 
   resources :categories do

--- a/db/migrate/20180326224403_create_comments.rb
+++ b/db/migrate/20180326224403_create_comments.rb
@@ -1,0 +1,8 @@
+class CreateComments < ActiveRecord::Migration[5.1]
+  def change
+    create_table :comments do |t|
+      t.string :content
+      t.references :job, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180325175219) do
+ActiveRecord::Schema.define(version: 20180326224403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "categories", force: :cascade do |t|
     t.string "title"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.string "content"
+    t.bigint "job_id"
+    t.index ["job_id"], name: "index_comments_on_job_id"
   end
 
   create_table "companies", force: :cascade do |t|
@@ -38,6 +44,7 @@ ActiveRecord::Schema.define(version: 20180325175219) do
     t.index ["company_id"], name: "index_jobs_on_company_id"
   end
 
+  add_foreign_key "comments", "jobs"
   add_foreign_key "jobs", "categories"
   add_foreign_key "jobs", "companies"
 end

--- a/spec/features/comments/user_can_make_comment_on_job_spec.rb
+++ b/spec/features/comments/user_can_make_comment_on_job_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe "User sees one job" do
+  scenario "a user leaves a comment on a job" do
+    company = Company.create!(name: "ESPN")
+    category = Category.create!(title: "Category")
+    job = company.jobs.create!(title: "Developer", level_of_interest: 90, city: "Denver", category_id: category.id)
+
+    visit company_job_path(company, job)
+
+    fill_in "comment[content]", with: "Adding a comment"
+    click_button "Create Comment"
+
+    expect(current_path).to eq(company_job_path(company, job))
+    expect(page).to have_content("Adding a comment")
+    expect(Comment.all.count).to eq(1)
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe Comment do
+  describe "validations" do
+    context "invalid attributes" do
+      it "is invalid without content" do
+        comment = Comment.new()
+        expect(comment).to be_invalid
+      end
+    end
+
+    context "valid attributes" do
+      it "is valid with a name and job" do
+        company = Company.new(name: "Turing")
+        category = Category.create!(title: "Category")
+        job = Job.create!(title: "Developer", level_of_interest: 40, city: "Denver", company: company, category_id: category.id)
+        comment = Comment.create!(content: "Adding content", job_id: job.id)
+        expect(comment).to be_valid
+      end
+    end
+  end
+
+  describe "relationships" do
+    it "has a job" do
+      job = Job.new(title: "Developer", description: "Wahoo", city: "Denver")
+      comment = Comment.new(content: "Adding content", job_id: job.id)
+      expect(comment).to respond_to(:job)
+    end
+  end
+end


### PR DESCRIPTION
@jrambold Would love some feedback on this. There is a comments controller, but since comments are being added on the job show pages, a lot of the logic is living in the job controller with the exception of comments#create.

One other thing of note - The comments routes are nested within jobs which are nested within companies. We might need to refactor this with the work that you're doing in mind.